### PR TITLE
Fix route resolution priority

### DIFF
--- a/packages/pocketpages/src/handlers/AfterBootstrapHandler.ts
+++ b/packages/pocketpages/src/handlers/AfterBootstrapHandler.ts
@@ -240,6 +240,21 @@ export const AfterBootstrapHandler: PagesInitializerFunc = (e) => {
       return route
     })
     .filter((r) => r.segments.length > 0)
+    // Ensure static routes are evaluated before dynamic ones
+    // and keep ordering deterministic for equal cases.
+    .sort((a, b) => {
+      const countParams = (r: Route) =>
+        r.segments.reduce((count, seg) => count + (seg.paramName ? 1 : 0), 0)
+      // Fewer dynamic parameters means a more specific (static) route
+      const aParams = countParams(a)
+      const bParams = countParams(b)
+      if (aParams !== bParams) return aParams - bParams
+      // If parameter counts are equal, prefer deeper paths first
+      if (a.segments.length !== b.segments.length)
+        return b.segments.length - a.segments.length
+      // Stabilize sort for identical shapes using the route path
+      return a.relativePath.localeCompare(b.relativePath)
+    })
   dbg({ routes })
 
   dbg({ config })


### PR DESCRIPTION
## Summary
- ensure static routes are prioritized before dynamic ones when building the route list
- document how route sorting works

## Testing
- `npx prettier --write packages/pocketpages/src/handlers/AfterBootstrapHandler.ts`


------
https://chatgpt.com/codex/tasks/task_e_688bcb8054e88333af149c3b40ad0de3